### PR TITLE
feat: add "Privacy Policy" page

### DIFF
--- a/src/app/[locale]/privacy-policy/layout.tsx
+++ b/src/app/[locale]/privacy-policy/layout.tsx
@@ -1,0 +1,22 @@
+import { Body, Header, Heading, PageSection } from "@/components/ui";
+import { getDictionary } from "@/locale/get-dictionary";
+
+export default async function PrivacyPolicyLayout({
+  children,
+  params: { locale },
+}: {
+  children: React.ReactNode;
+} & PageLocaleParams) {
+  const dictionary = await getDictionary(locale);
+  const privacyPolicyDictionary = dictionary.privacyPolicy;
+
+  return (
+    <main>
+      <Header>
+        <Heading level={1}>{privacyPolicyDictionary.heading}</Heading>
+        <Body level={1}>{privacyPolicyDictionary.body}</Body>
+      </Header>
+      <PageSection>{children}</PageSection>
+    </main>
+  );
+}

--- a/src/app/[locale]/privacy-policy/page.tsx
+++ b/src/app/[locale]/privacy-policy/page.tsx
@@ -1,18 +1,6 @@
-import { Body, Header, Heading } from "@/components/ui";
-import { getDictionary } from "@/locale/get-dictionary";
+import { ArticleComposer } from "@/components";
+import { privacyPolicyArticlesData } from "@/constants/privacyPolicy";
 
-export default async function PrivacyPolicy({
-  params: { locale },
-}: PageLocaleParams) {
-  const dictionary = await getDictionary(locale);
-  const privacyPolicyDictionary = dictionary.privacyPolicy;
-
-  return (
-    <main>
-      <Header>
-        <Heading level={1}>{privacyPolicyDictionary.heading}</Heading>
-        <Body level={1}>{privacyPolicyDictionary.body}</Body>
-      </Header>
-    </main>
-  );
+export default function PrivacyPolicy() {
+  return <ArticleComposer articleData={privacyPolicyArticlesData} />;
 }

--- a/src/components/ArticleComposer/ArticleComposer.tsx
+++ b/src/components/ArticleComposer/ArticleComposer.tsx
@@ -1,0 +1,19 @@
+import { Article, ArticleWrapper } from "@/components/ui";
+import { renderBody, renderHeading } from "@/lib/articleComposer/helpers";
+
+import { type ArticleComposerProps } from "./interfaces";
+
+export default function ArticleComposer({ articleData }: ArticleComposerProps) {
+  return (
+    <ArticleWrapper>
+      {articleData.map(({ id, gap, content }) => (
+        <Article key={id} gapVariant={gap}>
+          {content.map((item) => {
+            if (item.type === "heading") return renderHeading(item);
+            if (item.type === "body") return renderBody(item);
+          })}
+        </Article>
+      ))}
+    </ArticleWrapper>
+  );
+}

--- a/src/components/ArticleComposer/interfaces.ts
+++ b/src/components/ArticleComposer/interfaces.ts
@@ -1,0 +1,5 @@
+import { type ArticleData } from "@/types/article";
+
+export interface ArticleComposerProps {
+  articleData: ArticleData[];
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+export { default as ArticleComposer } from "./ArticleComposer/ArticleComposer";
 export { default as LayoutFooter } from "./LayoutFooter/LayoutFooter";
 export { default as LayoutNavbar } from "./LayoutNavbar/LayoutNavbar";
 export { default as ModalShell } from "./ModalShell/ModalShell";

--- a/src/components/ui/Article/Article.module.scss
+++ b/src/components/ui/Article/Article.module.scss
@@ -1,0 +1,16 @@
+.wrapper {
+    display: flex;
+    flex-direction: column;
+}
+
+.gap__small {
+    gap: 16px;
+}
+
+.gap__regular {
+    gap: 24px;
+}
+
+.gap__large {
+    gap: 32px;
+}

--- a/src/components/ui/Article/Article.stories.tsx
+++ b/src/components/ui/Article/Article.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Body, Display } from "@/components/ui";
+
+import Article from "./Article";
+
+const meta = {
+  title: "Components/Article",
+  component: Article,
+  argTypes: {
+    gapVariant: {
+      description: "Gap sizing between article items",
+      type: "string",
+      defaultValue: "regular",
+      options: ["small", "regular", "large"],
+      control: { type: "radio" },
+    },
+    children: {
+      description: "Article wrapper items",
+      options: ["Multiple", "None"],
+      control: { type: "radio" },
+      mapping: {
+        Multiple: (
+          <>
+            <Display>Display text</Display>
+            <Body>Body text</Body>
+          </>
+        ),
+        None: null,
+      },
+    },
+  },
+  args: {
+    children: "Multiple",
+    gapVariant: "regular",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof Article>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Multiple: Story = {
+  args: {
+    children: "Multiple",
+  },
+};
+
+export const None: Story = {
+  args: {
+    children: "None",
+  },
+};
+
+export const GapSmall: Story = {
+  args: {
+    children: "Multiple",
+    gapVariant: "small",
+  },
+};
+
+export const GapLarge: Story = {
+  args: {
+    children: "Multiple",
+    gapVariant: "large",
+  },
+};

--- a/src/components/ui/Article/Article.test.tsx
+++ b/src/components/ui/Article/Article.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import Article from "./Article";
+
+describe("Article", () => {
+  test("should render article with content and gap variant regular by default", () => {
+    render(
+      <Article>
+        <p>Content</p>
+      </Article>,
+    );
+
+    const article = screen.getByTestId("article");
+    const articleContent = screen.getByText(/Content/i);
+
+    expect(articleContent).toBeInTheDocument();
+    expect(article.nodeName.toLowerCase()).toEqual("article");
+    expect(article.className).toEqual("wrapper gap__regular");
+  });
+
+  test("should render article with gap variant regular small", () => {
+    render(
+      <Article gapVariant="small">
+        <p>Content</p>
+      </Article>,
+    );
+
+    const article = screen.getByTestId("article");
+
+    expect(article.nodeName.toLowerCase()).toEqual("article");
+    expect(article.className).toEqual("wrapper gap__small");
+  });
+
+  test("should render article with gap variant regular large", () => {
+    render(
+      <Article gapVariant="large">
+        <p>Content</p>
+      </Article>,
+    );
+
+    const article = screen.getByTestId("article");
+
+    expect(article.nodeName.toLowerCase()).toEqual("article");
+    expect(article.className).toEqual("wrapper gap__large");
+  });
+});

--- a/src/components/ui/Article/Article.tsx
+++ b/src/components/ui/Article/Article.tsx
@@ -1,0 +1,18 @@
+import clsx from "clsx";
+
+import styles from "./Article.module.scss";
+import { type ArticleProps } from "./interfaces";
+
+export default function Article({
+  children,
+  gapVariant = "regular",
+}: ArticleProps) {
+  return (
+    <article
+      data-testid="article"
+      className={clsx(styles.wrapper, styles[`gap__${gapVariant}`])}
+    >
+      {children}
+    </article>
+  );
+}

--- a/src/components/ui/Article/interfaces.ts
+++ b/src/components/ui/Article/interfaces.ts
@@ -1,0 +1,5 @@
+import { type PropsWithChildren } from "react";
+
+export interface ArticleProps extends PropsWithChildren {
+  gapVariant?: "small" | "regular" | "large";
+}

--- a/src/components/ui/ArticleWrapper/ArticleWrapper.module.scss
+++ b/src/components/ui/ArticleWrapper/ArticleWrapper.module.scss
@@ -1,0 +1,5 @@
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+}

--- a/src/components/ui/ArticleWrapper/ArticleWrapper.stories.tsx
+++ b/src/components/ui/ArticleWrapper/ArticleWrapper.stories.tsx
@@ -2,14 +2,14 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { Display } from "@/components/ui";
 
-import ModalWrapper from "./ModalWrapper";
+import ArticleWrapper from "./ArticleWrapper";
 
 const meta = {
-  title: "Components/ModalWrapper",
-  component: ModalWrapper,
+  title: "Components/ArticleWrapper",
+  component: ArticleWrapper,
   argTypes: {
     children: {
-      description: "Modal wrapper items",
+      description: "Article wrapper items",
       options: ["Single", "None"],
       control: { type: "radio" },
       mapping: {
@@ -19,7 +19,7 @@ const meta = {
     },
   },
   tags: ["autodocs"],
-} satisfies Meta<typeof ModalWrapper>;
+} satisfies Meta<typeof ArticleWrapper>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/components/ui/ArticleWrapper/ArticleWrapper.test.tsx
+++ b/src/components/ui/ArticleWrapper/ArticleWrapper.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import ArticleWrapper from "./ArticleWrapper";
+
+describe("ArticleWrapper", () => {
+  test("should render article wrapper with content", () => {
+    render(
+      <ArticleWrapper>
+        <p>Content</p>
+      </ArticleWrapper>,
+    );
+
+    const articleWrapper = screen.getByTestId("article-wrapper");
+    const wrapperContent = screen.getByText(/Content/i);
+
+    expect(wrapperContent).toBeInTheDocument();
+    expect(articleWrapper.nodeName.toLowerCase()).toEqual("div");
+    expect(articleWrapper.className).toEqual("wrapper");
+  });
+});

--- a/src/components/ui/ArticleWrapper/ArticleWrapper.tsx
+++ b/src/components/ui/ArticleWrapper/ArticleWrapper.tsx
@@ -1,0 +1,10 @@
+import styles from "./ArticleWrapper.module.scss";
+import { type ArticleWrapperProps } from "./interfaces";
+
+export default function ArticleWrapper({ children }: ArticleWrapperProps) {
+  return (
+    <div data-testid="article-wrapper" className={styles.wrapper}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/ArticleWrapper/interfaces.ts
+++ b/src/components/ui/ArticleWrapper/interfaces.ts
@@ -1,0 +1,3 @@
+import { type PropsWithChildren } from "react";
+
+export type ArticleWrapperProps = PropsWithChildren;

--- a/src/components/ui/Body/Body.module.scss
+++ b/src/components/ui/Body/Body.module.scss
@@ -8,6 +8,10 @@ $bodyFontWeight: 400;
     font-weight: $bodyFontWeight;
 }
 
+.body__secondary {
+    color: $darkGray;
+}
+
 .body__inter {
     font-family: $interFont;
 }
@@ -19,9 +23,19 @@ $bodyFontWeight: 400;
 .body__1 {
     font-size: 16px;
     line-height: 28px;
+
+    @media (max-width: $breakpoint-mobile) {
+        font-size: 14px;
+        line-height: 22px;
+    }
 }
 
 .body__2 {
     font-size: 14px;
     line-height: 20px;
+
+    @media (max-width: $breakpoint-mobile) {
+        font-size: 12px;
+        line-height: 18px;
+    }
 }

--- a/src/components/ui/Body/Body.stories.ts
+++ b/src/components/ui/Body/Body.stories.ts
@@ -18,6 +18,11 @@ const meta = {
       type: "number",
       defaultValue: 1,
     },
+    isSecondary: {
+      description: "Controls secondary variant of body (darker font color)",
+      type: "boolean",
+      defaultValue: false,
+    },
     font: {
       description: "The font family",
       type: "string",
@@ -29,6 +34,7 @@ const meta = {
   args: {
     level: 1,
     font: "inter",
+    isSecondary: false,
   },
   tags: ["autodocs"],
 } satisfies Meta<typeof Body>;
@@ -53,5 +59,12 @@ export const BodyWithSen: Story = {
   args: {
     children: "Sen body",
     font: "sen",
+  },
+};
+
+export const SecondaryBody: Story = {
+  args: {
+    children: "Secondary body",
+    isSecondary: true,
   },
 };

--- a/src/components/ui/Body/Body.test.tsx
+++ b/src/components/ui/Body/Body.test.tsx
@@ -33,4 +33,14 @@ describe("Body", () => {
     expect(body.nodeName.toLowerCase()).toEqual("p");
     expect(body.className).toEqual("body body__sen body__1");
   });
+
+  test("should render body with isSecondary property", () => {
+    render(<Body isSecondary>Secondary body</Body>);
+
+    const body = screen.getByText(/Secondary body/i);
+
+    expect(body).toBeInTheDocument();
+    expect(body.nodeName.toLowerCase()).toEqual("p");
+    expect(body.className).toEqual("body body__inter body__1 body__secondary");
+  });
 });

--- a/src/components/ui/Body/Body.tsx
+++ b/src/components/ui/Body/Body.tsx
@@ -7,6 +7,7 @@ export default function Body({
   children,
   level = 1,
   font = "inter",
+  isSecondary = false,
 }: BodyProps) {
   return (
     <p
@@ -14,6 +15,9 @@ export default function Body({
         styles.body,
         styles[`body__${font}`],
         styles[`body__${level}`],
+        {
+          [styles.body__secondary!]: isSecondary,
+        },
       )}
     >
       {children}

--- a/src/components/ui/Body/interfaces.ts
+++ b/src/components/ui/Body/interfaces.ts
@@ -7,4 +7,5 @@ type BodyLevels = 1 | 2;
 export interface BodyProps extends PropsWithChildren {
   level?: BodyLevels;
   font?: FontVariants;
+  isSecondary?: boolean;
 }

--- a/src/components/ui/Heading/Heading.module.scss
+++ b/src/components/ui/Heading/Heading.module.scss
@@ -20,31 +20,61 @@ $headingFontWeight: 700;
     font-size: 48px;
     line-height: 64px;
     letter-spacing: -2px;
+
+    @media (max-width: $breakpoint-mobile) {
+        font-size: 36px;
+        line-height: 48px;
+    }
 }
 
 .heading__2 {
     font-size: 36px;
     line-height: 48px;
     letter-spacing: -2px;
+
+    @media (max-width: $breakpoint-mobile) {
+        font-size: 28px;
+        line-height: 40px;
+    }
 }
 
 .heading__3 {
     font-size: 28px;
     line-height: 40px;
     letter-spacing: -1px;
+
+    @media (max-width: $breakpoint-mobile) {
+        font-size: 24px;
+        line-height: 32px;
+    }
 }
 
 .heading__4 {
     font-size: 24px;
     line-height: 32px;
+
+    @media (max-width: $breakpoint-mobile) {
+        font-size: 20px;
+        line-height: 28px;
+    }
 }
 
 .heading__5 {
     font-size: 20px;
     line-height: 32px;
+
+    @media (max-width: $breakpoint-mobile) {
+        font-size: 16px;
+        line-height: 24px;
+    }
 }
 
 .heading__6 {
     font-size: 16px;
     line-height: 24px;
+
+    @media (max-width: $breakpoint-mobile) {
+        font-size: 12px;
+        line-height: 20px;
+    }
 }

--- a/src/components/ui/PageSection/PageSection.module.scss
+++ b/src/components/ui/PageSection/PageSection.module.scss
@@ -1,0 +1,10 @@
+.wrapper {
+    margin: 128px auto;
+    width: 50%;
+
+    @media (max-width: $breakpoint-mobile) {
+        width: 100%;
+        margin: 128px 0px;
+        padding: 0px 24px;
+    }
+}

--- a/src/components/ui/PageSection/PageSection.stories.tsx
+++ b/src/components/ui/PageSection/PageSection.stories.tsx
@@ -2,14 +2,14 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { Display } from "@/components/ui";
 
-import ModalWrapper from "./ModalWrapper";
+import PageSection from "./PageSection";
 
 const meta = {
-  title: "Components/ModalWrapper",
-  component: ModalWrapper,
+  title: "Components/PageSection",
+  component: PageSection,
   argTypes: {
     children: {
-      description: "Modal wrapper items",
+      description: "Page section items",
       options: ["Single", "None"],
       control: { type: "radio" },
       mapping: {
@@ -19,7 +19,7 @@ const meta = {
     },
   },
   tags: ["autodocs"],
-} satisfies Meta<typeof ModalWrapper>;
+} satisfies Meta<typeof PageSection>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/components/ui/PageSection/PageSection.test.tsx
+++ b/src/components/ui/PageSection/PageSection.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import PageSection from "./PageSection";
+
+describe("PageSection", () => {
+  test("should render page section with content", () => {
+    render(
+      <PageSection>
+        <p>Content</p>
+      </PageSection>,
+    );
+
+    const pageSection = screen.getByTestId("page-section");
+    const sectionContent = screen.getByText(/Content/i);
+
+    expect(sectionContent).toBeInTheDocument();
+    expect(pageSection.nodeName.toLowerCase()).toEqual("section");
+    expect(pageSection.className).toEqual("wrapper");
+  });
+});

--- a/src/components/ui/PageSection/PageSection.tsx
+++ b/src/components/ui/PageSection/PageSection.tsx
@@ -1,0 +1,10 @@
+import { type PageSectionProps } from "./interfaces";
+import styles from "./PageSection.module.scss";
+
+export default function PageSection({ children }: PageSectionProps) {
+  return (
+    <section data-testid="page-section" className={styles.wrapper}>
+      {children}
+    </section>
+  );
+}

--- a/src/components/ui/PageSection/interfaces.ts
+++ b/src/components/ui/PageSection/interfaces.ts
@@ -1,0 +1,3 @@
+import { type PropsWithChildren } from "react";
+
+export type PageSectionProps = PropsWithChildren;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,3 +1,5 @@
+export { default as Article } from "./Article/Article";
+export { default as ArticleWrapper } from "./ArticleWrapper/ArticleWrapper";
 export { default as Body } from "./Body/Body";
 export { default as Button } from "./Button/Button";
 export { default as Display } from "./Display/Display";
@@ -9,3 +11,4 @@ export { default as Input } from "./Input/Input";
 export { default as Label } from "./Label/Label";
 export { default as ModalWrapper } from "./ModalWrapper/ModalWrapper";
 export { default as Navbar } from "./Navbar/Navbar";
+export { default as PageSection } from "./PageSection/PageSection";

--- a/src/constants/privacyPolicy.ts
+++ b/src/constants/privacyPolicy.ts
@@ -1,0 +1,36 @@
+import { type ArticleData } from "@/types/article";
+
+export const privacyPolicyArticlesData: ArticleData[] = [
+  {
+    id: "first-block",
+    gap: "large",
+    content: [
+      {
+        type: "heading",
+        data: "Lorem ipsum dolor sit amet",
+      },
+      {
+        type: "body",
+        data: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Non blandit massa enim nec. Scelerisque viverra mauris in aliquam sem. At risus viverra adipiscing at in tellus. Sociis natoque penatibus et magnis dis parturient montes. Ridiculus mus mauris vitae ultricies leo. Neque egestas congue quisque egestas diam. Risus in hendrerit gravida rutrum quisque non. Sit amet nulla facilisi morbi tempus iaculis urna. Lorem sed risus ultricies tristique nulla aliquet enim. Volutpat blandit aliquam etiam erat velit. Orci eu lobortis elementum nibh. Ipsum suspendisse ultrices gravida dictum fusce ut placerat orci nulla. Neque convallis a cras semper auctor neque vitae tempus quam.`,
+        isSecondary: true,
+      },
+    ],
+  },
+  {
+    id: "second-block",
+    content: [
+      {
+        type: "heading",
+        data: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.",
+        level: 2,
+      },
+      {
+        type: "body",
+        data: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Non blandit massa enim nec. Scelerisque viverra mauris in aliquam sem. At risus viverra adipiscing at in tellus. Sociis natoque penatibus et magnis dis parturient montes. Ridiculus mus mauris vitae ultricies leo. Neque egestas congue quisque egestas diam. Risus in hendrerit gravida rutrum quisque non. Sit amet nulla facilisi morbi tempus iaculis urna. Lorem sed risus ultricies tristique nulla aliquet enim. Volutpat blandit aliquam etiam erat velit. Orci eu lobortis elementum nibh. Ipsum suspendisse ultrices gravida dictum fusce ut placerat orci nulla. Neque convallis a cras semper auctor neque vitae tempus quam.
+
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Non blandit massa enim nec. Scelerisque viverra mauris in aliquam sem. At risus viverra adipiscing at in tellus. Sociis natoque penatibus et magnis dis parturient montes. Ridiculus mus mauris vitae ultricies leo. Neque egestas congue quisque egestas diam. Risus in hendrerit gravida rutrum quisque non. Sit amet nulla facilisi morbi tempus iaculis urna. Lorem sed risus ultricies tristique nulla aliquet enim. Volutpat blandit aliquam etiam erat velit. Orci eu lobortis elementum nibh. Ipsum suspendisse ultrices gravida dictum fusce ut placerat orci nulla. Neque convallis a cras semper auctor neque vitae tempus quam.`,
+        isSecondary: true,
+      },
+    ],
+  },
+];

--- a/src/lib/articleComposer/helpers.tsx
+++ b/src/lib/articleComposer/helpers.tsx
@@ -1,0 +1,27 @@
+import { Body, Heading } from "@/components/ui";
+import {
+  type ArticleContentBody,
+  type ArticleContentHeading,
+} from "@/types/article";
+
+export function renderHeading(item: ArticleContentHeading) {
+  const { type, data, level } = item;
+  const headingKey = `${type}-${level}-${data.slice(0, 20)}`;
+
+  return (
+    <Heading key={headingKey} level={level}>
+      {data}
+    </Heading>
+  );
+}
+
+export function renderBody(item: ArticleContentBody) {
+  const { type, data, isSecondary } = item;
+  const bodyKey = `${type}-${isSecondary}-${data.slice(0, 20)}`;
+
+  return (
+    <Body key={bodyKey} isSecondary={isSecondary}>
+      {data}
+    </Body>
+  );
+}

--- a/src/styles/variable.scss
+++ b/src/styles/variable.scss
@@ -19,3 +19,5 @@ $subscribeBlockBackgroundColor: rgba(255, 255, 255, .05);
 $modalWrapperBackgroundColor: rgba(0, 0, 0, 0.7);
 
 $disabledOpacity: 0.6;
+
+$breakpoint-mobile: 768px;

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -1,0 +1,18 @@
+export type ArticleContentHeading = {
+  type: "heading";
+  data: string;
+  level?: 1 | 2 | 3 | 4 | 5 | 6;
+};
+export type ArticleContentBody = {
+  type: "body";
+  data: string;
+  isSecondary?: boolean;
+};
+
+export type ArticleContent = ArticleContentHeading | ArticleContentBody;
+
+export type ArticleData = {
+  id: string;
+  gap?: "small" | "regular" | "large";
+  content: ArticleContent[];
+};


### PR DESCRIPTION
Данный PR добавляет готовую страницу Privacy Policy и также внедряет несколько полезных UI компонентов для сборки страницы с артиклями (секции текста между заголовками) и специальный компонент `ArticleComposer`, который собирает итоговую структуру страницы отталкиваясь от входного файла со специальной структурой, которая определена в `types/article.ts`

Также теперь `Header` находится в layout-файле для роута privacy-policy, в котором также `children` обернут в `PageSection`, который добавляет необходимые отступы и ширину контента