### PR TITLE
feat: tweak lazy load parameters for Home Page

### DIFF
--- a/src/app/[locale]/_components/HomeHero/HomeHero.tsx
+++ b/src/app/[locale]/_components/HomeHero/HomeHero.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 
 import { AuthorLink, Body, Button, Cap, Heading } from "@/components/ui";
 import { routes } from "@/constants/routes";
+import { withLazyLoad } from "@/hocs/withLazyLoad/withLazyLoad";
 import { findAuthorByID } from "@/lib/authors/findAuthorByID";
 import { getFormattedDate } from "@/lib/date";
 import { findPostByID } from "@/lib/posts/findPostByID";
@@ -11,7 +12,7 @@ import { findPostByID } from "@/lib/posts/findPostByID";
 import styles from "./HomeHero.module.scss";
 import { type HomeHeroProps } from "./interfaces";
 
-export default function HomeHero({
+function HomeHero({
   locale,
   heroPostId,
   dictionary,
@@ -62,3 +63,5 @@ export default function HomeHero({
     </div>
   );
 }
+
+export default withLazyLoad(HomeHero);

--- a/src/app/[locale]/_components/HomeHero/HomeHero.tsx
+++ b/src/app/[locale]/_components/HomeHero/HomeHero.tsx
@@ -64,4 +64,6 @@ function HomeHero({
   );
 }
 
-export default withLazyLoad(HomeHero);
+export default withLazyLoad(HomeHero, {
+  hasTransformY: false,
+});

--- a/src/app/[locale]/_components/LazyAuthorsGrid/LazyAuthorsGrid.tsx
+++ b/src/app/[locale]/_components/LazyAuthorsGrid/LazyAuthorsGrid.tsx
@@ -4,4 +4,6 @@ import { withLazyLoad } from "@/hocs/withLazyLoad/withLazyLoad";
 
 import AuthorsGrid from "../AuthorsGrid/AuthorsGrid";
 
-export default withLazyLoad(AuthorsGrid, 0.3);
+export default withLazyLoad(AuthorsGrid, {
+  threshold: 0.3,
+});

--- a/src/app/[locale]/_components/LazyAuthorsGrid/LazyAuthorsGrid.tsx
+++ b/src/app/[locale]/_components/LazyAuthorsGrid/LazyAuthorsGrid.tsx
@@ -4,4 +4,4 @@ import { withLazyLoad } from "@/hocs/withLazyLoad/withLazyLoad";
 
 import AuthorsGrid from "../AuthorsGrid/AuthorsGrid";
 
-export default withLazyLoad(AuthorsGrid);
+export default withLazyLoad(AuthorsGrid, 0.3);

--- a/src/app/[locale]/_components/PostsBlock/PostsBlock.tsx
+++ b/src/app/[locale]/_components/PostsBlock/PostsBlock.tsx
@@ -52,4 +52,4 @@ function PostsBlock({
   );
 }
 
-export default withLazyLoad(PostsBlock, 0.2);
+export default withLazyLoad(PostsBlock, 0.3);

--- a/src/app/[locale]/_components/PostsBlock/PostsBlock.tsx
+++ b/src/app/[locale]/_components/PostsBlock/PostsBlock.tsx
@@ -52,4 +52,6 @@ function PostsBlock({
   );
 }
 
-export default withLazyLoad(PostsBlock, 0.3);
+export default withLazyLoad(PostsBlock, {
+  threshold: 0.3,
+});

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -37,14 +37,14 @@ export default async function Home({ params: { locale } }: PageLocaleParams) {
 
   return (
     <main>
-      <HomeHero
-        locale={locale}
-        heroPostId={CURRENT_HERO_POST_ID}
-        dictionary={heroPostBlock}
-        categories={categoryGrid.categories}
-      />
-      <PageSection fullWidth>
-        <Suspense fallback={<MainPageSkeleton />}>
+      <Suspense fallback={<MainPageSkeleton />}>
+        <HomeHero
+          locale={locale}
+          heroPostId={CURRENT_HERO_POST_ID}
+          dictionary={heroPostBlock}
+          categories={categoryGrid.categories}
+        />
+        <PageSection fullWidth>
           <PostsBlock
             locale={locale}
             dictionary={postsBlock}
@@ -58,8 +58,8 @@ export default async function Home({ params: { locale } }: PageLocaleParams) {
           <FeaturedInBlock dictionary={featuredIn} />
           <TestimonialsBlock dictionary={testimonials} />
           <LazyJoinUsBlock locale={locale} dictionary={joinUs} />
-        </Suspense>
-      </PageSection>
+        </PageSection>
+      </Suspense>
     </main>
   );
 }

--- a/src/hocs/withLazyLoad/withLazyLoad.module.scss
+++ b/src/hocs/withLazyLoad/withLazyLoad.module.scss
@@ -13,10 +13,13 @@ $lazyWrapperTransition: all 0.8s ease;
     height: 100%;
     opacity: 0;
     transition: $lazyWrapperTransition;
-    transform: translateY(60px);
 }
 
 .isVisible {
     opacity: 1;
     transform: translateY(0px);
+}
+
+.transform {
+    transform: translateY(60px);
 }

--- a/src/hocs/withLazyLoad/withLazyLoad.module.scss
+++ b/src/hocs/withLazyLoad/withLazyLoad.module.scss
@@ -13,13 +13,15 @@ $lazyWrapperTransition: all 0.8s ease;
     height: 100%;
     opacity: 0;
     transition: $lazyWrapperTransition;
+    transform: translateY(60px);
+}
+
+.wrapper__no_transform {
+    transform: translateY(0px);
+
 }
 
 .isVisible {
     opacity: 1;
     transform: translateY(0px);
-}
-
-.transform {
-    transform: translateY(60px);
 }

--- a/src/hocs/withLazyLoad/withLazyLoad.tsx
+++ b/src/hocs/withLazyLoad/withLazyLoad.tsx
@@ -23,8 +23,8 @@ export const withLazyLoad = <P extends object>(
       <div
         ref={ref}
         className={clsx(styles.wrapper, {
+          [styles.wrapper__no_transform!]: !hasTransformY,
           [styles.isVisible!]: hasLoaded,
-          [styles.transform!]: hasTransformY,
         })}
       >
         <WrappedComponent {...props} />

--- a/src/hocs/withLazyLoad/withLazyLoad.tsx
+++ b/src/hocs/withLazyLoad/withLazyLoad.tsx
@@ -7,8 +7,12 @@ import styles from "./withLazyLoad.module.scss";
 
 export const withLazyLoad = <P extends object>(
   WrappedComponent: ComponentType<P>,
-  threshold = 0.6,
+  options?: {
+    threshold?: number;
+    hasTransformY?: boolean;
+  },
 ): React.FC<P> => {
+  const { threshold = 0.6, hasTransformY = true } = options ?? {};
   const displayName =
     WrappedComponent.displayName ?? WrappedComponent.name ?? "Component";
 
@@ -20,6 +24,7 @@ export const withLazyLoad = <P extends object>(
         ref={ref}
         className={clsx(styles.wrapper, {
           [styles.isVisible!]: hasLoaded,
+          [styles.transform!]: hasTransformY,
         })}
       >
         <WrappedComponent {...props} />


### PR DESCRIPTION
- Блоки `PostsBlock` и `LazyAuthorsGrid` имеют теперь значение `threshold` равному 0.3 (Лучше работает появление на мобильной версии)
- HOC `withLazyLoad` теперь принимает настройки как объект, который является опциональным по дефолту
- Добавлена настройка для отключения `transformY` (Используется для `HomeHero`)