### PR TITLE
feat: add logic for styling disabled option

### DIFF
--- a/src/components/form/Select/Select.module.scss
+++ b/src/components/form/Select/Select.module.scss
@@ -27,6 +27,10 @@
     }
 }
 
+.disabledOption {
+    color: $mediumGray;
+}
+
 .errorMessage {
     @include formErrorMessage;
 }

--- a/src/components/form/Select/Select.module.scss
+++ b/src/components/form/Select/Select.module.scss
@@ -27,7 +27,7 @@
     }
 }
 
-.disabledOption {
+.select__disabled {
     color: $mediumGray;
 }
 

--- a/src/components/form/Select/Select.test.tsx
+++ b/src/components/form/Select/Select.test.tsx
@@ -12,6 +12,15 @@ describe("Select", () => {
     },
   ];
 
+  const disabledOption = [
+    {
+      id: "test",
+      name: "test",
+      value: "test",
+      isDisabled: true,
+    },
+  ];
+
   test("should render select", () => {
     render(<Select options={defaultOptions} />);
 
@@ -40,5 +49,15 @@ describe("Select", () => {
     expect(errorMessage.textContent).toEqual("Hello!");
     expect(errorMessage.nodeName.toLowerCase()).toEqual("span");
     expect(errorMessage.className).toEqual("errorMessage");
+  });
+
+  test("should render disabled select with another class", () => {
+    render(<Select value="test" options={disabledOption} />);
+
+    const select = screen.getByTestId("select");
+
+    expect(select).toBeInTheDocument();
+    expect(select.nodeName.toLowerCase()).toEqual("select");
+    expect(select.className).toEqual("select select__disabled");
   });
 });

--- a/src/components/form/Select/Select.tsx
+++ b/src/components/form/Select/Select.tsx
@@ -22,8 +22,8 @@ export default function Select({
       <select
         data-testid="select"
         className={clsx(styles.select, {
+          [styles.select__disabled!]: isSelectedDisabled,
           [styles.full_padding!]: fullPadding,
-          [styles.disabledOption!]: isSelectedDisabled,
         })}
         {...props}
       >

--- a/src/components/form/Select/Select.tsx
+++ b/src/components/form/Select/Select.tsx
@@ -9,12 +9,21 @@ export default function Select({
   errorMessage,
   ...props
 }: SelectProps) {
+  const disabledValues = options
+    .filter((option) => option.isDisabled)
+    .map((option) => option.value);
+  const isSelectedDisabled =
+    props.value !== undefined
+      ? disabledValues.includes(String(props.value))
+      : false;
+
   return (
     <div data-testid="select-wrapper">
       <select
         data-testid="select"
         className={clsx(styles.select, {
           [styles.full_padding!]: fullPadding,
+          [styles.disabledOption!]: isSelectedDisabled,
         })}
         {...props}
       >


### PR DESCRIPTION
Теперь, если в `select` выбран `option` в положении `disabled`, то `select` дополняется стилем, который меняет цвет текста на серый